### PR TITLE
Fix markdown linter issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,22 @@
  repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.8.0
     hooks:
       - id: black
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-yaml
+      - id: check-toml
+      - id: check-xml
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: check-ast
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: debug-statements
+      - id: mixed-line-ending
+  - repo: https://github.com/asottile/reorder_python_imports
+    rev: v3.8.2
+    hooks:
+      - id: reorder-python-imports

--- a/arcgispro/src/readme.md
+++ b/arcgispro/src/readme.md
@@ -1,18 +1,19 @@
 # "Permanent" ArcGIS Pro Toolbox Install
+
 * This directory contains the files necessary to permanently add the `3D Data Co-Registration` toolbox to the set of available ArcGIS Pro Geoprocessing toolboxes (see Fig. 1).
 * See the below Reference list for how to generate and distribute the necessary files.
 * If desired, the files in the `coregister/esri/toolboxes` directory can still be used to manually import the toolbox.
 
-    ![](./images/geoprocessing_toolboxes.png)
+    ![geoprocessing toolboxes](./images/geoprocessing_toolboxes.png)
 
     **Fig. 1 - 3D Registration toolbox permanently installed.**
 
-
 ## References
+
 1. [Online ESRI documentation for creating geoprocessing modules](https://pro.arcgis.com/en/pro-app/latest/arcpy/geoprocessing_and_python/extending-geoprocessing-through-python-modules.htm)
 2. [Online ESRI documentation for distributing geoprocessing modules](https://pro.arcgis.com/en/pro-app/latest/arcpy/geoprocessing_and_python/distributing-python-modules.htm)
 
 ## Notes
+
 1. You need to choose how to distribute the module. You can either copy the files as they exist (first option in reference \#2) or build a wheel with `setup.py` and use `pip` (second option in reference \#2) to install it into the Conda environment.
 2. You should regenerate the files (see reference \#1) in this directory if any of the toolbox files (`*.pyt*` files) are changed.
-

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,9 +1,10 @@
 # Configuring CODEM
 
 ## Overview
+
 Numerous algorithm parameters can be tuned when running `CODEM` by specifying option names and values. The available options can be viewed by running `codem --help`:
 
-```
+```bash
 $ codem --help
 usage: codem [-h] [--min_resolution MIN_RESOLUTION] [--dsm_akaze_threshold DSM_AKAZE_THRESHOLD]
              [--dsm_lowes_ratio DSM_LOWES_RATIO] [--dsm_ransac_max_iter DSM_RANSAC_MAX_ITER]
@@ -15,121 +16,122 @@ usage: codem [-h] [--min_resolution MIN_RESOLUTION] [--dsm_akaze_threshold DSM_A
              foundation_file aoi_file
 ```
 
-In most cases, the default parameter values (see below) are sufficient. 
-
+In most cases, the default parameter values (see below) are sufficient.
 
 ## Configuration Parameters
+
 Option values must adhere to the following limits and data types:
 
 **Coarse, Feature-Based Registration Parameters:**
+
 * `DSM_STRONG_FILTER`
-    * description: standard deviation of the large Gaussian filter used to normalize the DSM prior to feature extraction; larger values allow longer wavelength vertical features to pass through into the normalized DSM
-    * command line argument: `-dst` or `--dsm_strong_filter`
-    * units: meters
-    * dtype: `float`
-    * limits: `x > 0.0`
-    * default: `10`
+  * description: standard deviation of the large Gaussian filter used to normalize the DSM prior to feature extraction; larger values allow longer wavelength vertical features to pass through into the normalized DSM
+  * command line argument: `-dst` or `--dsm_strong_filter`
+  * units: meters
+  * dtype: `float`
+  * limits: `x > 0.0`
+  * default: `10`
 * `DSM_WEAK_FILTER`
-    * description: standard deviation of the small Gaussian filter used to normalize the DSM prior to feature extraction; larger values increasingly blur short wavelength vertical features in the normalized DSM
-    * command line argument: `dwf` or `--dsm_weak_filter`
-    * units: meters
-    * dtype: `float`
-    * limits: `x > 0.0`
-    * default: `1`
+  * description: standard deviation of the small Gaussian filter used to normalize the DSM prior to feature extraction; larger values increasingly blur short wavelength vertical features in the normalized DSM
+  * command line argument: `dwf` or `--dsm_weak_filter`
+  * units: meters
+  * dtype: `float`
+  * limits: `x > 0.0`
+  * default: `1`
 * `DSM_AKAZE_THRESHOLD`
-    * description: [Accelerated-KAZE](http://www.bmva.org/bmvc/2013/Papers/paper0013/paper0013.pdf) feature detection response threshold; larger values require increasingly distinctive local geometry for a feature to be detected
-    * command line argument: `-dat` or `--dsm_akaze_threshold`
-    * units: none
-    * dtype: `float`
-    * limits: `x > 0.0`
-    * default: `0.0001`
+  * description: [Accelerated-KAZE](http://www.bmva.org/bmvc/2013/Papers/paper0013/paper0013.pdf) feature detection response threshold; larger values require increasingly distinctive local geometry for a feature to be detected
+  * command line argument: `-dat` or `--dsm_akaze_threshold`
+  * units: none
+  * dtype: `float`
+  * limits: `x > 0.0`
+  * default: `0.0001`
 * `DSM_LOWES_RATIO`
-    * description: feature matching relative strength control; larger values allow weaker matches relative to the next best match
-    * command line argument: `-dlr` or `--dsm_lowes_ratio`
-    * units: none
-    * dtype: `float`
-    * limits: `0.0 < x < 1.0`
-    * default: `0.9`
+  * description: feature matching relative strength control; larger values allow weaker matches relative to the next best match
+  * command line argument: `-dlr` or `--dsm_lowes_ratio`
+  * units: none
+  * dtype: `float`
+  * limits: `0.0 < x < 1.0`
+  * default: `0.9`
 * `DSM_RANSAC_THRESHOLD`
-    * description: maximum residual error for a matched feature pair to be included in a random sample consensus (RANSAC) solution to a 3D registration transformation; larger values include matched feature pairs with increasingly greater disagreement with the solution
-    * command line argument: `-drt` or `--dsm_ransac_threshold`
-    * units: meters
-    * dtype: `float`
-    * limits: `x > 0`
-    * default: `10`
+  * description: maximum residual error for a matched feature pair to be included in a random sample consensus (RANSAC) solution to a 3D registration transformation; larger values include matched feature pairs with increasingly greater disagreement with the solution
+  * command line argument: `-drt` or `--dsm_ransac_threshold`
+  * units: meters
+  * dtype: `float`
+  * limits: `x > 0`
+  * default: `10`
 * `DSM_RANSAC_MAX_ITER`
-    * description: the max iterations for the RANSAC algorithm
-    * command line argument: `-drmi` or `--dsm_ransac_max_iter`
-    * units: iterations
-    * dtype: `int`
-    * limits: `x > 0`
-    * default: `10000`
+  * description: the max iterations for the RANSAC algorithm
+  * command line argument: `-drmi` or `--dsm_ransac_max_iter`
+  * units: iterations
+  * dtype: `int`
+  * limits: `x > 0`
+  * default: `10000`
 * `DSM_SOLVE_SCALE`
-    * description: flag to include or exclude scale from the solved coarse registration transformation
-    * command line argument: `-dss` or `--dsm_solve_scale`
-    * units: N/A
-    * dtype: `bool`
-    * limits: `True` or `False`
-    * default: `True`
+  * description: flag to include or exclude scale from the solved coarse registration transformation
+  * command line argument: `-dss` or `--dsm_solve_scale`
+  * units: N/A
+  * dtype: `bool`
+  * limits: `True` or `False`
+  * default: `True`
 
 **Fine, ICP-Based Registration Parameters:**
+
 * `ICP_MAX_ITER`
-    * description: the max iterations for the iterative closest point algorithm
-    * command line argument: `-imi` or `--icp_max_iter`
-    * units: iterations
-    * dtype: `int`
-    * limits: `x > 0`
-    * default: `100`
+  * description: the max iterations for the iterative closest point algorithm
+  * command line argument: `-imi` or `--icp_max_iter`
+  * units: iterations
+  * dtype: `int`
+  * limits: `x > 0`
+  * default: `100`
 * `ICP_RMSE_THRESHOLD`
-    * description: ICP convergence criterion; minimum relative change between iterations in the root mean squared error
-    * command line argument: `-irt` or `--icp_rmse_threshold`
-    * units: meters
-    * dtype: `float`
-    * limits: `x > 0`
-    * default: `0.0001`
+  * description: ICP convergence criterion; minimum relative change between iterations in the root mean squared error
+  * command line argument: `-irt` or `--icp_rmse_threshold`
+  * units: meters
+  * dtype: `float`
+  * limits: `x > 0`
+  * default: `0.0001`
 * `ICP_ANGLE_THRESHOLD`
-    * description: ICP convergence criterion; minimum change in Euler angle between iterations
-    * command line argument: `-iat` or `--icp_angle_threshold`
-    * units: degrees
-    * dtype: `float`
-    * limits: `x > 0`
-    * default: `0.001`
+  * description: ICP convergence criterion; minimum change in Euler angle between iterations
+  * command line argument: `-iat` or `--icp_angle_threshold`
+  * units: degrees
+  * dtype: `float`
+  * limits: `x > 0`
+  * default: `0.001`
 * `ICP_DISTANCE_THRESHOLD`
-    * description: ICP convergence criterion; minimum change in translation between iterations
-    * command line argument: `-idt` or `--icp_distance_threshold`
-    * units: meters
-    * dtype: `float`
-    * limits: `x > 0`
-    * default: `0.001`
+  * description: ICP convergence criterion; minimum change in translation between iterations
+  * command line argument: `-idt` or `--icp_distance_threshold`
+  * units: meters
+  * dtype: `float`
+  * limits: `x > 0`
+  * default: `0.001`
 * `ICP_SOLVE_SCALE`
-    * description: flag to include or exclude scale from the solved fine registration transformation
-    * command line argument: `-iss` or `--icp_solve_scale`
-    * units: N/A
-    * dtype: `bool`
-    * limits: `True` or `False`
-    * default: `True`
+  * description: flag to include or exclude scale from the solved fine registration transformation
+  * command line argument: `-iss` or `--icp_solve_scale`
+  * units: N/A
+  * dtype: `bool`
+  * limits: `True` or `False`
+  * default: `True`
 * `ICP_ROBUST`
-    * description: flag to include or exclude robust weighting in the fine registration solution
-    * command line argument: `-ir` or `--icp_robust`
-    * units: N/A
-    * dtype: `bool`
-    * limits: `True` or `False`
-    * default: `True`
+  * description: flag to include or exclude robust weighting in the fine registration solution
+  * command line argument: `-ir` or `--icp_robust`
+  * units: N/A
+  * dtype: `bool`
+  * limits: `True` or `False`
+  * default: `True`
 
 **Other Parameters:**
+
 * `MIN_RESOLUTION`
-    * description: the minimum pipeline data resolution; smaller values increase computation time
-    * command line argument: `-min` or `--min_resolution`
-    * units: meters
-    * dtype: `float`
-    * limits: `x > 0`
-    * default: `1.0`
+  * description: the minimum pipeline data resolution; smaller values increase computation time
+  * command line argument: `-min` or `--min_resolution`
+  * units: meters
+  * dtype: `float`
+  * limits: `x > 0`
+  * default: `1.0`
 * `VERBOSE`
-    * description: flag to output verbose logging information to the console
-    * command line argument: `-v` or `--verbose`
-    * units: N/A
-    * dtype: `bool`
-    * limits: `True` or `False`
-    * default: `False`
-
-
+  * description: flag to output verbose logging information to the console
+  * command line argument: `-v` or `--verbose`
+  * units: N/A
+  * dtype: `bool`
+  * limits: `True` or `False`
+  * default: `False`

--- a/docs/details.md
+++ b/docs/details.md
@@ -1,9 +1,11 @@
 # Detailed Overview
+
 `CODEM` (Multi-Modal Digital Elevation Model Registration) is a spatial data co-registration tool developed in Python.
 
-
 ## Concept
+
 Conceptually, `CODEM` consists of two back-to-back registration modules:
+
 1. An initial coarse global registration based on matched features extracted from digital surface models (DSMs) generated from the AOI and Foundation data sources.
 2. A fine local registration based on an iterative closest point (ICP) algorithm applied to the AOI and Foundation data.
 
@@ -13,33 +15,40 @@ A flowchart illustrating the registration pipeline is given below.
 
 ![`CODEM` flowchart](./img/flowchart.png)
 
-
 ## Pipeline Details
+
 ### 1. Preprocessing
+
 #### *Resolution Detection*
-Prior to any data processing, the resolutions (i.e., point spacings) of the Foundation and AOI data are determined and the pipeline resolution set to the larger of the two. However, if this resolution value is still smaller than the threshold specified by the `MIN_RESOLUTION` parameter, then the pipeline resolution is set to the `MIN_RESOLUTION` value. 
+
+Prior to any data processing, the resolutions (i.e., point spacings) of the Foundation and AOI data are determined and the pipeline resolution set to the larger of the two. However, if this resolution value is still smaller than the threshold specified by the `MIN_RESOLUTION` parameter, then the pipeline resolution is set to the `MIN_RESOLUTION` value.
 
 The existence of differing distance units (meters, feet, U.S. survey feet) between the Foundation and AOI data files is checked and accommodated in the determined resolution, which is always in meters. If distance units are not specified in a file, the meter unit is assumed.
 
 #### *DSM Creation*
-The first registration module uses matched features extracted from DSM data. DSMs are therefore created from the Foundation and AOI data with the resolution, i.e., pixel spacing, set to the pipeline resolution. Missing pixels are infilled via inverse distance weighted interpolation. 
+
+The first registration module uses matched features extracted from DSM data. DSMs are therefore created from the Foundation and AOI data with the resolution, i.e., pixel spacing, set to the pipeline resolution. Missing pixels are infilled via inverse distance weighted interpolation.
 
 #### *DSM Normalization*
-The eventual feature extraction algorithms operate on 8-bit raster data. If the Foundation and/or AOI DSMs contain large elevation changes, e.g., mountainous terrain, features defined by relatively small changes in elevation such as buildings and vegetation will be suppressed when quantized to 8-bits. Therefore, long-wavelength elevation changes, e.g., the slope of a mountain, are removed by applying a bandpass filter to the DSM data prior to the 8-bit conversion. 
+
+The eventual feature extraction algorithms operate on 8-bit raster data. If the Foundation and/or AOI DSMs contain large elevation changes, e.g., mountainous terrain, features defined by relatively small changes in elevation such as buildings and vegetation will be suppressed when quantized to 8-bits. Therefore, long-wavelength elevation changes, e.g., the slope of a mountain, are removed by applying a bandpass filter to the DSM data prior to the 8-bit conversion.
 
 The bandpass filter removes elevation changes occurring over large horizontal distances while retaining elevation changes that occur at small horizontal distances. Thus, local feature such as buildings, small slopes, and vegetation texture are able to be preserved when the DSM is quantized to 8-bits. A small amount of smoothing is also applied to elevation changes occurring at very short distances to filter noise.
 
 #### *Point Cloud Creation*
+
 The second registration module is an ICP algorithm. Point clouds are generated from the created DSMs (not the normalized DSMs) for the ICP algorithm. Each pixel is simply converted to a 3D point with geospatial coordinates.
 
 ### 2. Feature-Based Registration
-[AKAZE](http://www.bmva.org/bmvc/2013/Papers/paper0013/paper0013.pdf) (Accelerated-KAZE) features are extracted from the normalized and quantized Foundation and AOI DSMs. [SIFT](https://link.springer.com/article/10.1023/B:VISI.0000029664.99615.94) features were found to perform similarly, but the algorithm was patent-protected until recently. 
+
+[AKAZE](http://www.bmva.org/bmvc/2013/Papers/paper0013/paper0013.pdf) (Accelerated-KAZE) features are extracted from the normalized and quantized Foundation and AOI DSMs. [SIFT](https://link.springer.com/article/10.1023/B:VISI.0000029664.99615.94) features were found to perform similarly, but the algorithm was patent-protected until recently.
 
 Each AOI feature is matched to the most similar Foundation feature according to nearness in feature space. The matched features are initially filtered using the standard [Lowe's ratio test](https://link.springer.com/article/10.1023/B:VISI.0000029664.99615.94). RANSAC is then applied to the filtered matches to determine the matched feature locations that best define a 6- or 7-parameter transformation from the AOI to Foundation coordinate system.
 
-Feature matching is blind to spatial location. Thus, the feature-based registration does not require the Foundation and AOI data to be in the same coordinate system. However, a few meters or more of error typically remain after a feature-based registration. 
+Feature matching is blind to spatial location. Thus, the feature-based registration does not require the Foundation and AOI data to be in the same coordinate system. However, a few meters or more of error typically remain after a feature-based registration.
 
 ### 3. ICP-Based Registration
+
 The purpose of the ICP registration is to remove much of the error remaining in the feature-based registration result. A point to plane ICP algorithm is used with hard and soft outlier thresholds applied to the closest point matches to reduce the effect of systematic error and temporal change in the Foundation and AOI data. The hard threshold value is set from the root mean square error of the feature-based registration. A soft threshold is enforced by employing iteratively re-weighted least squares for the ICP solution.
 
 ICP is a local registration solution and requires an initial guess to get started. The transformation solved in the feature-based registration serves this purpose. The ICP algorithm uses the Foundation and AOI point clouds created in the Preprocessing step and iterates until a minimum change in motion (distance or angle) or mean square error between the matched points is achieved.
@@ -47,13 +56,15 @@ ICP is a local registration solution and requires an initial guess to get starte
 The final registration transformation is the product of the ICP fine registration transformation matrix and the feature-based registration transformation matrix.
 
 ### 4. Registration Application to AOI Data
+
 The final registration transformation is applied to the original AOI data file to transform the AOI data into the Foundation data coordinate system and the updated AOI data is saved to a new file with the term "`_registered`" appended to the file name. Note that the distance unit and coordinate reference system of the new AOI data file will match that of the Foundation data.
 
-
 ## Inputs & Outputs
+
 `CODEM` was designed to be agnostic to data types and file formats. Thus, `CODEM` accepts point cloud, mesh, and DSM data types. File formats are currently limited to LAS, LAZ, and BPF for point clouds, PLY and OBJ for mesh data, and GeoTIFF images for DSMs. Additionally file formats can be added if necessary, as I/O for each data type is handled by generic libraries: [PDAL](https://pdal.io/) for point clouds, [trimesh](https://trimsh.org/index.html) for mesh data, and [GDAL](https://gdal.org/) for DSM raster products.
 
 All output is saved to a new directory that is created at the location of the AOI file. The directory name is tagged with the date and time of execution: `registration_YYYY-MM-DD_HH-MM-SS`. The directory contents include the following:
+
 1. Registered AOI Data File: The registered AOI file will be of the same data type and file format as the original AOI file and will have the same name with term "`_registered`" appended to end of the name.
 2. `config.yml`: A record of the parameters used in the registration.
 3. `log.txt`: A log file that may be useful for debugging or insight into reasons for a failed registration.
@@ -66,10 +77,10 @@ All output is saved to a new directory that is created at the location of the AO
 
 **Example registration parameter output:**
 
-```
+```console
 DSM FEATURE REGISTRATION
 ------------------------
-Transformation matrix: 
+Transformation matrix:
  [[ 9.99234831e-01 -2.11892556e-04 -1.74235703e-04  1.39586681e+03]
  [ 2.12011646e-04  9.99234613e-01  6.83244873e-04  3.17553089e+03]
  [ 1.74090772e-04 -6.83281816e-04  9.99234620e-01  2.84471944e+03]
@@ -91,7 +102,7 @@ Z = +/-0.804,
 
 ICP REGISTRATION
 ----------------
-Transformation matrix: 
+Transformation matrix:
  [[ 9.99578165e-01 -3.87857454e-04 -9.49183210e-05  1.94055589e+03]
  [ 3.87859287e-04  9.99578169e-01  1.92820610e-05  1.58154769e+03]
  [ 9.49108320e-05 -1.93188899e-05  9.99578240e-01  2.40643763e+01]
@@ -113,16 +124,14 @@ Z = +/-0.315,
 
 ```
 
-
 ## Assumptions and Limitations
+
 * `CODEM` assumes the Foundation and AOI data has been preprocessed to remove stray data, e.g., in-air points from atmospheric returns in lidar point clouds. Additional preprocessing filters can be added to `CODEM` if necessary.
 * DSM data (GeoTIFF format) must not contain a rotation or differing scales in the X and Y directions (these are defined by the transform in the GeoTIFF file). `CODEM` will abort the registration process if either of these conditions is encountered.
 * Very small areas (e.g., 100 x 100 meters) or very coarse resolution data (e.g., a DSM with 10 meter pixels) may contain insufficient information for `CODEM` to solve the registration.
 * Data file formats are currently limited to the following (more can be added if necessary):
-    * Point Clouds: LAS, LAZ, and BPF
-    * DSMs: GeoTIFF
-    * Mesh: PLY and OBJ
+  * Point Clouds: LAS, LAZ, and BPF
+  * DSMs: GeoTIFF
+  * Mesh: PLY and OBJ
 * `CODEM` cannot handle large (> 50%) differences in scale between Foundation and AOI data.
 * If data a lacks linear unit type, meters will be assumed.
-
-

--- a/docs/example.md
+++ b/docs/example.md
@@ -1,17 +1,19 @@
 # Example
 
 ## 1. Unregistered AOI
+
 We will register a PLY format mesh AOI to a LAZ format point cloud Foundation data source. The AOI mesh data (color) is rotated and displaced with respect to the Foundation point cloud (grayscale). The data files are found in the `demo` directory of this repository.
+
 * Foundation file = `demo/Foundation-PointCloud.laz`
 * AOI file = `demo/AOI-Mesh.ply`
 
-
 ![Example Unregistered](./img/example_unregistered.png)
 
-
 ## 2. Running CODEM
+
 We will override the default setting for the pipeline minimum resolution by using the `--min_resolution` option when running `CODEM`:
-```
+
+```bash
 $ codem demo/Foundation-PointCloud.laz demo/AOI-Mesh.ply --min_resolution 2.0
 ╔════════════════════════════════════╗
 ║               CODEM                ║
@@ -63,15 +65,17 @@ $ codem demo/Foundation-PointCloud.laz demo/AOI-Mesh.ply --min_resolution 2.0
 
 CODEM                                  Stage: Performing Fine Registration                                   00:16
 Registration Process 100%|█████████████████████████████████████████████████████████| 100/100 [00:17<00:00, 5.84/s]
-$ 
+$
 ```
 
 Upon completion, all output, including a registered version of the AOI data file named `AOI-Mesh_registered.ply`, is saved to a new directory at the AOI file location. For this example, the new directory name is `registration_2021-08-05_11-11-49`.
 
 ## 3. Registered AOI
+
 The registered AOI mesh overlaid on the Foundation point cloud is shown below.
 
 ![Example Registered](./img/example_registered.png)
 
 ## 4. Additional Examples
+
 An unregistered point cloud AOI file and an unregistered DSM AOI file are also supplied in the `demo` directory for further experimentation/demonstration with different data types.

--- a/readme.md
+++ b/readme.md
@@ -1,81 +1,88 @@
 # CODEM: Multi-Modal Digital Elevation Model Registration
+
 ![Registered Mesh](./docs/img/reg_mesh.png)
 
-
 ## Overview
+
 `CODEM` is a testbed application for registering a 3D model of an area of interest (AOI) to a larger 3D Foundation data source. Point cloud, mesh, and raster digital surface model (DSM) data types are supported. Format support is limited to the following:
+
 * Point Cloud: LAS, LAZ, BPF
 * Mesh: PLY, OBJ
 * DSM: GeoTIFF
 
 `CODEM` follows the following basic steps to perform co-registration:
+
 1. Generation of normalized DSMs from the AOI and Foundation data sources.
 2. Coarse registration via matching of features extracted from the DSMs.
 3. Fine registration via an iterative closest point (ICP) algorithm.
 4. Application of the solved registration transformation to the AOI data in its original type and format.
 
-
 ## Installing CODEM
+
 1. Clone the repo:
 
-    ```
+    ```console
     git clone https://github.com/NCALM-UH/CODEM
     ```
 
-
 2. Create and activate a Conda environment containing the required dependencies. From inside the `CODEM` directory:
 
-    ```
+    ```console
     conda env create --file environment.yml
     ```
-    ```
+
+    ```console
     conda activate codem
     ```
 
-3. Install `CODEM`. From inside the `codem` directory:
-    ```
+3. Install `CODEM`. From the project directory.
+
+    ```console
     pip install .
     ```
 
-
 ## Running CODEM
+
 The `CODEM` application has two required positional arguments and numerous options. The required positional arguments are the file path to the Foundation data file and the file path to the AOI data file. Executing codem on the command line has the following form:
-```
+
+```bash
 codem <foundation_file_path> <aoi_file_path> [-opt option_value]
 ```
 
 For example, running `CODEM` on some of the sample data files in the [demo](demo) directory looks like:
-```
+
+```bash
 codem demo/Foundation-PointCloud.laz demo/AOI-Mesh.ply
 ```
 
 Optional arguments can be placed before or after the positional arguments. For example, we can set the minimum registration pipeline resolution to a new value (default value = 1.0):
-```
+
+```bash
 codem demo/Foundation-PointCloud.laz demo/AOI-Mesh.ply --min_resolution 2.0
 ```
 
 A summary of all options and their default values is given in the [docs/configuration.md](docs/configuration.md) document. The default option values should be sufficient for most landscapes.
 
-
 ## Generated Output
+
 All output is saved to a new directory that is created at the location of the AOI file. The directory name is tagged with the date and time of execution: `registration_YYYY-MM-DD_HH-MM-SS`. The directory contents include the following:
+
 1. Registered AOI Data File: The registered AOI file will be of the same data type and file format as the original AOI file and will have the same name with term "`_registered`" appended to end of the name.
 2. `config.yml`: A record of the parameters used in the registration.
 3. `log.txt`: A log file.
 4. `registration.txt`: Contains the solved coarse and fine registration transformation parameters and a few statistics.
 5. `dsm_feature_matches.png`: An image of the matched features used in the coarse registration step.
 
-
 ## Additional Information
+
 Information on available configuration options, a more in-depth review of how `CODEM` works, and a simple example utilizing data files contained in the `demo` directory of this repository are found in the `docs` directory:
+
 * [docs/configuration.md](docs/configuration.md)
 * [docs/details.md](docs/details.md)
 * [docs/example.md](docs/example.md)
-
 
 ## Contact
 
 * Ognyan Moore - Hobu Inc. - [Email](ogi@hobu.co)
 * Preston Hartzell - University of Houston - [Email](pjhartzell@uh.edu)
-* Jesse Shanahan - formerly of Booz Allen Hamilton (listed for software development credit attribution) - [LinkedIn](https://www.linkedin.com/in/jesseshanahan/) 
-
+* Jesse Shanahan - formerly of Booz Allen Hamilton (listed for software development credit attribution) - [LinkedIn](https://www.linkedin.com/in/jesseshanahan/)


### PR DESCRIPTION
This PR updates the markdown files so that the markdown linters have no issues.


In addition, the pre-commit-config to add more checks (and update the version of black being utilized). 