### PR TITLE
Replace some assert statements with runtime checks and such

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,4 +24,4 @@
     rev: v0.971
     hooks:
     -   id: mypy
-        additional_dependencies: [numpy==1.20.1]
+        additional_dependencies: [numpy~=1.20.0, types-PyYAML]

--- a/src/codem/registration/icp.py
+++ b/src/codem/registration/icp.py
@@ -323,12 +323,8 @@ class IcpRegistration:
         A = np.hstack((A1, A2, A3))
 
         if self.config["ICP_ROBUST"]:
-            assert (
-                np.linalg.det(A.T @ weights @ A) != 0
-            ), "Matrix is singular/non-invertible"
             x = np.linalg.inv(A.T @ weights @ A) @ A.T @ weights @ b
         else:
-            assert np.linalg.det(A.T @ A) != 0, "Matrix is singular/non-invertible"
             x = np.linalg.inv(A.T @ A) @ A.T @ b
 
         x[0:3] /= x[6]
@@ -401,12 +397,8 @@ class IcpRegistration:
         A = np.hstack((A1, A2))
 
         if self.config["ICP_ROBUST"]:
-            assert (
-                np.linalg.det(A.T @ weights @ A) != 0
-            ), "Matrix is singular/non-invertible"
             x = np.linalg.inv(A.T @ weights @ A) @ A.T @ weights @ b
         else:
-            assert np.linalg.det(A.T @ A) != 0, "Matrix is singular/non-invertible"
             x = np.linalg.inv(A.T @ A) @ A.T @ b
 
         x = np.linalg.inv(A.T @ A) @ A.T @ b


### PR DESCRIPTION
This PR does not remove all the assert checks in the runtime code-paths but removes many of them.

Some low-hanging fruit was removing the checks for the numpy determinant to be 0.  This can be safely done as the very next line is performing a (non-pseudo) matrix inversion, and if the matrix is not invertible, there will be a Singular matrix exception.

Some attributes were changed to be properties, so that value checking can be done in a safe manner.
