### PR TITLE
Handle Integer dtypes within rasters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,4 +24,5 @@
     rev: v0.971
     hooks:
     -   id: mypy
-        additional_dependencies: [numpy~=1.20.0, types-PyYAML]
+        language_version: python3.7
+        additional_dependencies: [numpy==1.20.3, types-PyYAML]

--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,5 @@ dependencies:
   - matplotlib
   - scikit-image
   - enlighten
+  - numpy==1.20.3
+  - typing-extensions

--- a/src/codem/preprocessing/preprocess.py
+++ b/src/codem/preprocessing/preprocess.py
@@ -309,6 +309,17 @@ class GeoData:
 
         self.processed = True
 
+    def _debug_plot(self, keypoints: Optional[np.ndarray] = None) -> None:
+        """Use this to show the raster"""
+        import matplotlib.pyplot as plt
+
+        img = plt.imshow(self.infilled, cmap="gray")
+        if keypoints is not None:
+            plt.scatter(
+                keypoints[:, 0], keypoints[:, 1], marker="s", color="orange", s=10.0
+            )
+        plt.show()
+
 
 class DSM(GeoData):
     """

--- a/src/codem/registration/dsm.py
+++ b/src/codem/registration/dsm.py
@@ -1,3 +1,4 @@
+
 """
 DsmRegistration.py
 Project: CRREL-NEGGS University of Houston Collaboration
@@ -226,7 +227,6 @@ class DsmRegistration:
             self.aoi_obj.area_or_point,
             self.aoi_obj.infilled,
         )
-
         # Find 3D similarity transform conforming to max number of matches
         if self.config["DSM_SOLVE_SCALE"]:
             model, inliers = ransac(
@@ -244,12 +244,16 @@ class DsmRegistration:
                 residual_threshold=self.config["DSM_RANSAC_THRESHOLD"],
                 max_trials=self.config["DSM_RANSAC_MAX_ITER"],
             )
-
-        self.logger.debug(f"{np.sum(inliers)} keypoint matches found.")
+        if model is None:
+            raise ValueError(
+                "ransac model not fitted, no inliers found. Consider tuning "
+                "DSM_RANSAC_THRESHOLD or DSM_RANSAC_MAX_ITER"
+            )
+        self.logger.info(f"{np.sum(inliers)} keypoint matches found.")
         assert np.sum(inliers) >= 4, "Less than four keypoint matches found."
 
         T: np.ndarray = model.transform
-        c = np.sqrt(T[0, 0] ** 2 + T[1, 0] ** 2 + T[2, 0] ** 2)
+        c = np.linalg.norm(T[:, 0])
         assert (
             c > 0.67 and c < 1.5
         ), "Solved scale difference between foundation and AOI data exceeds 50%"

--- a/src/codem/registration/dsm.py
+++ b/src/codem/registration/dsm.py
@@ -67,7 +67,7 @@ class DsmRegistration:
 
         if not aoi_obj.processed:
             raise RuntimeError(
-                "AOI data has not been pre-procssed, did you call the prep method?"
+                "AOI data has not been pre-processed, did you call the prep method?"
             )
         if not fnd_obj.processed:
             raise RuntimeError(


### PR DESCRIPTION
codem in its current capacity will not handle rasters that have data with integer dtypes.  This PR modifies the code-base to not raise exceptions during those cases.  It turns out that there is an issue with keypoint identification when rasters have integer based dtypes.  To work around the issue, data is converted to a float32 dtype when read in.  This issue should be revisited if there is a need to preserve the integer dtype.