### PR TITLE
Fix issues identified by ODM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ module = [
   "rasterio.crs",
   "rasterio.enums",
   "rasterio.fill",
+  "rich",
   "rich.console",
   "rich.logging",
   "rich.progress",

--- a/src/codem/main.py
+++ b/src/codem/main.py
@@ -416,7 +416,7 @@ def apply_registration(
     aoi_obj: GeoData,
     icp_reg: IcpRegistration,
     config: Dict[str, Any],
-    output_format: str = None,
+    output_format: Optional[str] = None,
 ) -> str:
     app_reg = ApplyRegistration(
         fnd_obj,

--- a/src/codem/preprocessing/preprocess.py
+++ b/src/codem/preprocessing/preprocess.py
@@ -99,7 +99,7 @@ class GeoData:
         self._resolution = 0.0
         self.native_resolution = 0.0
         self.units_factor = 1.0
-        self.units = None
+        self.units: Optional[str] = None
         self.weak_size = config["DSM_WEAK_FILTER"]
         self.strong_size = config["DSM_STRONG_FILTER"]
 
@@ -630,10 +630,13 @@ class Mesh(GeoData):
 
         mesh = trimesh.load_mesh(self.file)
         tag = ["AOI", "Foundation"][int(self.fnd)]
-        if mesh.units is None:
+
+        if not hasattr(mesh, "units") or mesh.units is None:
             self.logger.warning(
                 f"Linear unit for {tag}-{self.type.upper()} not detected --> meters assumed"
             )
+            self.units_factor = 1.0
+            self.units = "meters"
         else:
             self.logger.info(
                 f"Linear unit for {tag}-{self.type.upper()} detected as {mesh.units}"

--- a/src/vcd/main.py
+++ b/src/vcd/main.py
@@ -8,21 +8,61 @@ import os
 import time
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import Union
 
 import yaml
 from codem.lib.log import Log
 from distutils.util import strtobool
-from rich.console import Console
-from rich.logging import RichHandler
-from rich.progress import Progress
-from rich.progress import SpinnerColumn
-from rich.progress import TimeElapsedColumn
 from vcd.meshing.mesh import Mesh
 from vcd.preprocessing.preprocess import PointCloud
 from vcd.preprocessing.preprocess import VCD
 from vcd.preprocessing.preprocess import VCDParameters
+
+try:
+    import rich
+except ImportError:
+    _has_rich = False
+    from contextlib import ContextDecorator
+
+    class Progress(ContextDecorator):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__()
+
+        def __enter__(self, *args: Any, **kwargs: Any) -> Any:
+            return self
+
+        def __exit__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def add_task(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def advance(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        @staticmethod
+        def get_default_columns() -> List:
+            return []
+
+    class Dummy:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.level = float("-inf")
+
+        def print(self, *args: Any, **kwargs: Any) -> None:
+            print(*args)
+
+    Console = Dummy  # type: ignore
+    SpinnerColumn = TimeElapsedColumn = object  # type: ignore
+else:
+    _has_rich = True
+    from rich.console import Console  # type: ignore
+    from rich.logging import RichHandler  # type: ignore
+    from rich.progress import Progress  # type: ignore
+    from rich.progress import SpinnerColumn  # type: ignore
+    from rich.progress import TimeElapsedColumn  # type: ignore
 
 
 @dataclasses.dataclass
@@ -221,9 +261,16 @@ def main() -> None:
     args = get_args()
     config = create_config(args)
     console = Console()
-    rich_handler = RichHandler(level="DEBUG", console=console, markup=False)
+    log_handler: Union[rich.logging.RichHandler, logging.StreamHandler]
+    if _has_rich:
+        log_handler = rich.logging.RichHandler(
+            level="DEBUG", console=console, markup=False
+        )
+    else:
+        log_handler = logging.StreamHandler()
+        log_handler.setLevel(logging.DEBUG)
     codem_logger = Log(config)
-    codem_logger.logger.addHandler(rich_handler)
+    codem_logger.logger.addHandler(log_handler)
     run_console(config, codem_logger.logger, console)  # type: ignore
 
 


### PR DESCRIPTION
This PR addresses some issues identified by the team at open drone maps. 

Primary change how the minimum resolution parameter is calculated.  It now defaults to `float('nan')` where-as before it would default to 1.0.  If a value is not specified, the resolution is determined based on the foundation and AOI datasets.  If a resolution parameter is specified, that value is used.  If the value used will result in a coarser resolution than what the datasets can do, a warning will be emitted.

Furthermore, `rich` is now an optional dependency.  This makes it easier to interact with the debugger and makes it easier for integration downstream.