### PR TITLE
Better attempts to identify correct transform

### DIFF
--- a/src/vcd/preprocessing/preprocess.py
+++ b/src/vcd/preprocessing/preprocess.py
@@ -5,8 +5,6 @@ Date: February 2021
 
 """
 import contextlib
-import itertools
-import math
 import os
 import re
 from typing import List


### PR DESCRIPTION
Do away with always_xy=True when creating the pyproj transform group, and instead iterate through the available transforms until a suitable transformation is identified.