### PR TITLE
Apply colors to VCD pointcloud

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ module = [
   "cv2",
   "enlighten",
   "matplotlib",
+  "matplotlib.colors",
   "matplotlib.pyplot",
   "matplotlib.tri",
   "pandas",

--- a/src/vcd/main.py
+++ b/src/vcd/main.py
@@ -77,6 +77,7 @@ class VcdRunConfig:
     CLUSTER_TOLERANCE: float = 2.0
     CULL_CLUSTER_IDS: Tuple[int, ...] = (-1, 0, 1)
     OUTPUT_DIR: Optional[str] = None
+    COLORMAP: str = "RdBu"
 
     def __post_init__(self) -> None:
         # set output directory
@@ -171,7 +172,17 @@ def get_args() -> argparse.Namespace:
     ap.add_argument(
         "-v", "--verbose", action="count", default=0, help="turn on verbose logging"
     )
-
+    ap.add_argument(
+        "--colormap",
+        type=str,
+        default=VcdRunConfig.COLORMAP,
+        help=(
+            "Colormap to apply to generated output files where supported.  Name has "
+            "to align with a matplotlib named colormap.  See "
+            "https://matplotlib.org/stable/tutorials/colors/colormaps.html#diverging "
+            "for list of options."
+        ),
+    )
     args = ap.parse_args()
     return args
 

--- a/src/vcd/preprocessing/preprocess.py
+++ b/src/vcd/preprocessing/preprocess.py
@@ -323,6 +323,10 @@ class VCD:
                 resolution=resolution,
             ).pipeline(array)
             pipeline.execute()
+
+            # TODO:
+            # look at adding the colortable
+            # https://gis.stackexchange.com/questions/325615/store-geotiff-with-color-table-python/325751#325751
             return outfile
 
         def _merge(rasters: List[str], output_type: str) -> None:
@@ -383,6 +387,8 @@ class VCD:
         # Color the point cloud with a new/fled gradient
         flex_max = array["dZ3d"].min()
         new_max = array["dZ3d"].max()
+
+        # TODO: use product.colorscale colormap instead of manually specified variant.
 
         fled = np.flipud(plt.cm.Reds(np.linspace(0.0, 1.0, 256)))
         new = plt.cm.Blues(np.linspace(0.0, 1.0, 256))


### PR DESCRIPTION
This change adds color to the point cloud VCD output.  The color is based on new vs fled for the ground pointcloud only.  This uses the maplotlib blues and reds colormaps, although it would be trivial to create different ones.

One colormap is applied to points classified as fled, the other colormap is applied to the points classified as new.

![image](https://user-images.githubusercontent.com/646398/224176405-468180b3-3ab8-433a-b460-fbad3ccc6636.png)
