### PR TITLE
Add Feature to limit the search space for registration features

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,7 +32,7 @@ jobs:
           miniforge-variant: Mambaforge
           environment-file: environment.yml
           auto-update-conda: false
-          python-version: "3.7"
+          python-version: "3.9"
       - name: "Install Test Framework"
         run: pip install pytest
       - name: "Install Codem"
@@ -61,10 +61,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         # Semantic version range syntax or exact version of a Python version
-        python-version: '3.7'
+        python-version: '3.9'
     - name: Install Linting Tools
       run : |
-        python -m pip install mypy numpy==1.20.3 types-PyYAML typing-extensions
+        python -m pip install mypy numpy types-PyYAML typing-extensions
     - name: Run mypy
       run : mypy src
   analyze:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
  repos:
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -25,4 +25,4 @@
     hooks:
     -   id: mypy
         language_version: python3.9
-        additional_dependencies: [numpy==1.20.3, types-PyYAML]
+        additional_dependencies: [types-PyYAML]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codem"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 description = "A package for co-registering geospatial data"
 readme = "readme.md"
 license = { text = "Apache-2.0" }
@@ -66,7 +66,7 @@ exclude = '''
 '''
 
 [tool.mypy]
-python_version = 3.7
+python_version = 3.9
 warn_return_any = true
 disallow_untyped_defs = true
 disallow_untyped_calls = true
@@ -89,9 +89,11 @@ module = [
   "pyproj.enums",
   "pyproj.transformer",
   "rasterio",
+  "rasterio.coords",
   "rasterio.crs",
   "rasterio.enums",
   "rasterio.fill",
+  "rasterio.transform",
   "rich",
   "rich.console",
   "rich.logging",

--- a/src/codem/registration/dsm.py
+++ b/src/codem/registration/dsm.py
@@ -110,7 +110,7 @@ class DsmRegistration:
         if len(self.fnd_kp) < 4:
             raise RuntimeError(
                 (
-                    f"{len(self.fnd_kp)} keypoints were identiifed in the Foundation data"
+                    f"{len(self.fnd_kp)} keypoints were identified in the Foundation data"
                     " (4 required).  Consider modifying the DSM_AKAZE_THRESHOLD parameter,"
                     f" current value is {self.config['DSM_AKAZE_THRESHOLD']}"
                 )
@@ -123,7 +123,7 @@ class DsmRegistration:
         if len(self.aoi_kp) < 4:
             raise RuntimeError(
                 (
-                    f"{len(self.aoi_kp)} keypoints were identiifed in the "
+                    f"{len(self.aoi_kp)} keypoints were identified in the "
                     "AOI data (4 required).  Consider modifying the DSM_AKAZE_THRESHOLD"
                     f"parameter, current value is {self.config['DSM_AKAZE_THRESHOLD']}"
                 )
@@ -354,7 +354,7 @@ class DsmRegistration:
         """
         z = []
         for cr in uv:
-            cr_int = np.int32(np.rint(cr))
+            cr_int = np.rint(cr).astype(np.int32)
             z.append(dsm[cr_int[1], cr_int[0]])
 
         # When using the transform to convert from pixels to object space


### PR DESCRIPTION
This PR adds a feature to clip the rasterized representation of the datasets to what is likely an overlapping area.

This can lead to significant performance improvements if the area of the two datasets is substantially different (this can mean either the area is vastly different in size, or if the overlapping area of the two datasets is very small compared to the size of the two datasets).

For this feature to work, there are some requirements needed.

1. Both datasets need to have a defined _and_ equal CRS
2. Based on the defined CRS, the bounding boxes for the two datasets must have some overlap
  - This means that the compliment dataset must not be completely off-base.

Fixes #61 
