### PR TITLE
Fix tight search feature

### DIFF
--- a/src/codem/main.py
+++ b/src/codem/main.py
@@ -406,8 +406,11 @@ def preprocess(config: Dict[str, Any]) -> Tuple[GeoData, GeoData]:
     else:
         resolution = max(fnd_obj.native_resolution, aoi_obj.native_resolution)
     fnd_obj.resolution = aoi_obj.resolution = resolution
-    fnd_obj._create_dsm()
-    aoi_obj._create_dsm()
+
+    # create DSM, but if doing tight-search do not resample
+    resample = not config["TIGHT_SEARCH"]
+    fnd_obj._create_dsm(resample=resample)
+    aoi_obj._create_dsm(resample=resample)
     return fnd_obj, aoi_obj
 
 

--- a/src/codem/main.py
+++ b/src/codem/main.py
@@ -287,13 +287,12 @@ def get_args() -> argparse.Namespace:
         help="boolean to include or exclude scale from the solved registration",
     )
     ap.add_argument(
-        "--verbose", "-v", type=str2bool, default=False, help="turn on verbose logging"
+        "--verbose", "-v", action="store_true", help="turn on verbose logging"
     )
     ap.add_argument(
         "--tight-search",
         "-ts",
-        type=str2bool,
-        default=False,
+        action="store_true",
         help=(
             "Limits the registration search to the region of overlap. Both datasets "
             "must have the same CRS defined."

--- a/src/codem/preprocessing/preprocess.py
+++ b/src/codem/preprocessing/preprocess.py
@@ -312,7 +312,7 @@ class GeoData:
     def _calculate_resolution(self) -> None:
         raise NotImplementedError
 
-    def _create_dsm(self) -> None:
+    def _create_dsm(self, resample: bool = True) -> None:
         raise NotImplementedError
 
     def prep(self) -> None:
@@ -334,7 +334,10 @@ class GeoData:
         """Use this to show the raster"""
         import matplotlib.pyplot as plt
 
-        plt.imshow(self.infilled, cmap="gray")
+        if hasattr(self, "infilled"):
+            plt.imshow(self.infilled, cmap="gray")
+        else:
+            plt.imshow(self.dsm, cmap="gray")
         if keypoints is not None:
             plt.scatter(
                 keypoints[:, 0], keypoints[:, 1], marker="s", color="orange", s=10.0
@@ -352,13 +355,16 @@ class DSM(GeoData):
         self.type = "dsm"
         self._calculate_resolution()
 
-    def _create_dsm(self) -> None:
+    def _create_dsm(self, resample: bool = True) -> None:
         """
         Resamples the DSM to the registration pipeline resolution and applies
         a scale factor to convert to meters.
         """
+
         with rasterio.open(self.file) as data:
-            resample_factor = self.native_resolution / self.resolution
+            resample_factor = (
+                self.native_resolution / self.resolution if resample else 1.0
+            )
             tag = ["AOI", "Foundation"][int(self.fnd)]
             if resample_factor != 1:
                 self.logger.info(
@@ -500,7 +506,7 @@ class PointCloud(GeoData):
         self.type = "pcloud"
         self._calculate_resolution()
 
-    def _create_dsm(self) -> None:
+    def _create_dsm(self, resample: bool = True) -> None:
         """
         Converts the point cloud to meters and rasters it to a DSM.
         """
@@ -586,7 +592,7 @@ class Mesh(GeoData):
         self.type = "mesh"
         self._calculate_resolution()
 
-    def _create_dsm(self) -> None:
+    def _create_dsm(self, resample: bool = True) -> None:
         """
         Converts mesh vertices to meters and rasters them to a DSM.
         """
@@ -706,10 +712,6 @@ def clip_data(fnd_obj: GeoData, aoi_obj: GeoData, config: Dict[str, Any]) -> Non
     # how much outside of the bounds to search for registration features
     oversize_scale = 1.5
 
-    # need information on CRS
-    fnd_obj._create_dsm()
-    aoi_obj._create_dsm()
-
     if not config["TIGHT_SEARCH"]:
         return None
 
@@ -779,7 +781,9 @@ def clip_data(fnd_obj: GeoData, aoi_obj: GeoData, config: Dict[str, Any]) -> Non
             [clipped_bounding_boxes[key].top, clipped_bounding_boxes[key].bottom],
         )
         dataset_obj.window = windows.Window.from_slices(slice(*xs), slice(*ys))
-        dataset_obj._create_dsm()  # need to recreate the DSM with the window
+        # breakpoint()
+        # need that we know the window, create the DSM with resampling
+        dataset_obj._create_dsm(resample=True)
     return None
 
 


### PR DESCRIPTION
This PR addresses two issues.

1. There was a mistake in the calculation of what the search area should be.
2. When the window is calculated, that _could_ occur on a DSM that was resampled, resulting in indexes/slices that are not valid to use when reading in a raster, to begin with (as the windowing occurs _before_ the up/down sampling).

