### PR TITLE
Preserve raster pixel area or point

### DIFF
--- a/src/codem/__init__.py
+++ b/src/codem/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.25.0.dev0"
+__version__ = "0.25.1"
 
 import codem.lib.log as log
 import codem.lib.resources as resources

--- a/src/codem/main.py
+++ b/src/codem/main.py
@@ -287,6 +287,11 @@ def get_args() -> argparse.Namespace:
         help="boolean to include or exclude scale from the solved registration",
     )
     ap.add_argument(
+        "--icp-save-residuals",
+        action="store_true",
+        help="Write ICP residual information",
+    )
+    ap.add_argument(
         "--verbose", "-v", action="store_true", help="turn on verbose logging"
     )
     ap.add_argument(
@@ -320,7 +325,7 @@ def create_config(args: argparse.Namespace) -> Dict[str, Any]:
         ICP_ROBUST=args.icp_robust,
         ICP_SOLVE_SCALE=args.icp_solve_scale,
         VERBOSE=args.verbose,
-        ICP_SAVE_RESIDUALS=False,
+        ICP_SAVE_RESIDUALS=args.icp_save_residuals,
         TIGHT_SEARCH=args.tight_search,
     )
     return dataclasses.asdict(config)

--- a/src/codem/preprocessing/preprocess.py
+++ b/src/codem/preprocessing/preprocess.py
@@ -446,7 +446,6 @@ class DSM(GeoData):
                 self.logger.debug(
                     f"'AREA_OR_POINT' not supplied in {tag}-{self.type.upper()} - defaulting to 'Area'"
                 )
-
         if self.nodata is None:
             self.logger.info(f"{tag}-{self.type.upper()} does not have a nodata value.")
         if self.transform == rasterio.Affine.identity():
@@ -781,7 +780,6 @@ def clip_data(fnd_obj: GeoData, aoi_obj: GeoData, config: Dict[str, Any]) -> Non
             [clipped_bounding_boxes[key].top, clipped_bounding_boxes[key].bottom],
         )
         dataset_obj.window = windows.Window.from_slices(slice(*xs), slice(*ys))
-        # breakpoint()
         # need that we know the window, create the DSM with resampling
         dataset_obj._create_dsm(resample=True)
     return None

--- a/src/codem/registration/apply.py
+++ b/src/codem/registration/apply.py
@@ -84,8 +84,8 @@ class ApplyRegistration:
         self.aoi_units_factor = aoi_obj.units_factor
         self.aoi_type = aoi_obj.type
         self.aoi_area_or_point = aoi_obj.area_or_point
-        self.fnd_area_or_point = fnd_obj.area_or_point
         self.registration_transform = registration_parameters["matrix"]
+        self.registration_rmse = registration_parameters["rmse_3d"]
         self.residual_vectors = residual_vectors
         self.residual_origins = residual_origins
         self.config = config
@@ -185,7 +185,6 @@ class ApplyRegistration:
             "resolution": self.aoi_resolution,
             "output_type": "idw",
             "filename": output_path,
-            # TODO this might not be right, might be coma separated values!!!!
             "metadata": (
                 f"CODEM_VERSION={__version__},"
                 "TIFFTAG_IMAGEDESCRIPTION=RegisteredCompliment"
@@ -194,23 +193,6 @@ class ApplyRegistration:
 
         if self.aoi_area_or_point in ("Area", "Point"):
             writer_kwargs["metadata"] += f",AREA_OR_POINT={self.aoi_area_or_point}"  # type: ignore
-
-            # do we need to accommodate area or point offsets?
-            if (
-                self.fnd_area_or_point != "Unknown"
-                and self.fnd_area_or_point != self.aoi_area_or_point
-            ):
-                tx = 0.5 * self.aoi_resolution
-                ty = 0.5 * self.aoi_resolution
-                if self.fnd_area_or_point == "Area":
-                    # foundation is area
-                    # compliment is point
-                    matrix = f"0 0 0 {tx} 0 1 0 {ty} 0 0 1 0 0 0 0 1"
-                else:
-                    # foundation is point
-                    # compliment is area
-                    matrix = f"0 0 0 -{tx} 0 1 0 -{ty} 0 0 1 0 0 0 0 1"
-                pipeline |= pdal.Filter.transformation(matrix=matrix)
 
         if self.aoi_nodata is not None:
             writer_kwargs["nodata"] = self.aoi_nodata

--- a/src/codem/registration/apply.py
+++ b/src/codem/registration/apply.py
@@ -83,6 +83,8 @@ class ApplyRegistration:
         self.aoi_resolution = aoi_obj.native_resolution
         self.aoi_units_factor = aoi_obj.units_factor
         self.aoi_type = aoi_obj.type
+        self.aoi_area_or_point = aoi_obj.area_or_point
+        self.fnd_area_or_point = fnd_obj.area_or_point
         self.registration_transform = registration_parameters["matrix"]
         self.residual_vectors = residual_vectors
         self.residual_origins = residual_origins
@@ -99,7 +101,7 @@ class ApplyRegistration:
 
     def get_registration_transformation(
         self,
-    ) -> Union[np.ndarray, Dict[str, str]]:
+    ) -> Union[np.ndarray, pdal.Pipeline]:
         """
         Generates the transformation from the AOI to FND coordinate system.
         The transformation accommodates linear unit differences and the solved
@@ -128,16 +130,13 @@ class ApplyRegistration:
                 " ".join(item) for item in aoi_to_fnd_array.astype(str)
             ][0]
             if self.fnd_crs is not None:
-                registration_transformation = {
-                    "type": "filters.transformation",
-                    "matrix": aoi_to_fnd_string,
-                    "override_srs": self.fnd_crs.to_string(),
-                }
+                registration_transformation = pdal.Filter.transformation(
+                    matrix=aoi_to_fnd_string, override_srs=self.fnd_crs.to_string()
+                )
             else:
-                registration_transformation = {
-                    "type": "filters.transformation",
-                    "matrix": aoi_to_fnd_string,
-                }
+                registration_transformation = pdal.Filter.transforamtion(
+                    matrix=aoi_to_fnd_string
+                )
             return registration_transformation
 
     def apply(self) -> None:
@@ -164,43 +163,60 @@ class ApplyRegistration:
         output_path = os.path.join(self.config["OUTPUT_DIR"], output_name)
 
         # construct pdal pipeline
-        pipe = [{"type": "readers.gdal", "filename": self.aoi_file, "header": "Z"}]
+        pipeline = pdal.Reader.gdal(filename=self.aoi_file, header="Z")
 
         # no nodata is present, filter based on its limits
         if self.aoi_nodata is not None:
-            range_filter_task = {
-                "type": "filters.range",
-                "limits": f"Z![{self.aoi_nodata}:{self.aoi_nodata}]",
-            }
-            pipe.append(range_filter_task)
+            pipeline |= pdal.Filter.range(
+                limits=f"Z![{self.aoi_nodata}:{self.aoi_nodata}]"
+            )
 
         # insert the transform filter to register the AOI
         registration_task = self.get_registration_transformation()
-        if isinstance(registration_task, dict):
-            pipe.append(registration_task)
+        if isinstance(registration_task, pdal.pipeline.Filter):
+            pipeline |= registration_task
         else:
             raise ValueError(
                 f"get_registration_transformation returned {type(registration_task)} "
                 "not a dictionary of strings as needed for the pdal pipeline."
             )
 
-        # pdal writing task
-        writer_task = {
-            "type": "writers.gdal",
+        writer_kwargs = {
             "resolution": self.aoi_resolution,
             "output_type": "idw",
             "filename": output_path,
+            # TODO this might not be right, might be coma separated values!!!!
             "metadata": (
                 f"CODEM_VERSION={__version__},"
-                f"TIFFTAG_IMAGEDESCRIPTION=RegisteredCompliment"
+                "TIFFTAG_IMAGEDESCRIPTION=RegisteredCompliment"
             ),
         }
-        # Add nodata argument only if nodata is actually present
+
+        if self.aoi_area_or_point in ("Area", "Point"):
+            writer_kwargs["metadata"] += f",AREA_OR_POINT={self.aoi_area_or_point}"  # type: ignore
+
+            # do we need to accommodate area or point offsets?
+            if (
+                self.fnd_area_or_point != "Unknown"
+                and self.fnd_area_or_point != self.aoi_area_or_point
+            ):
+                tx = 0.5 * self.aoi_resolution
+                ty = 0.5 * self.aoi_resolution
+                if self.fnd_area_or_point == "Area":
+                    # foundation is area
+                    # compliment is point
+                    matrix = f"0 0 0 {tx} 0 1 0 {ty} 0 0 1 0 0 0 0 1"
+                else:
+                    # foundation is point
+                    # compliment is area
+                    matrix = f"0 0 0 -{tx} 0 1 0 -{ty} 0 0 1 0 0 0 0 1"
+                pipeline |= pdal.Filter.transformation(matrix=matrix)
+
         if self.aoi_nodata is not None:
-            writer_task["nodata"] = self.aoi_nodata
-        pipe.append(writer_task)
-        p = pdal.Pipeline(json.dumps(pipe))
-        p.execute()
+            writer_kwargs["nodata"] = self.aoi_nodata
+
+        pipeline |= pdal.Writer.gdal(**writer_kwargs)
+        pipeline.execute()
 
         self.logger.info(
             f"Registration has been applied to AOI-DSM and saved to: {self.out_name}"
@@ -257,7 +273,7 @@ class ApplyRegistration:
             # save the interpolated data to a new TIF file. We only save to TIF
             # files since they are known to handle additional bands.
             root, _ = os.path.splitext(self.out_name)
-            out_name_res = root + "_residuals.tif"
+            out_name_res = f"{root}_residuals.tif"
 
             profile.update(count=6, driver="GTiff")
 
@@ -335,23 +351,18 @@ class ApplyRegistration:
         """
         Applies the registration transformation to a point cloud file.
         """
-        pipe = [
-            self.aoi_file,
-            self.get_registration_transformation(),
-            self.out_name,
-        ]
-        p = pdal.Pipeline(json.dumps(pipe))
-        p.execute()
+        pipeline = pdal.Reader(self.aoi_file)
+        pipeline |= self.get_registration_transformation()
+        pipeline |= pdal.Writer.las(filename=self.out_name)
+
+        pipeline.execute()
         self.logger.info(
             f"Registration has been applied to AOI-PCLOUD and saved to: {self.out_name}"
         )
 
         if self.config["ICP_SAVE_RESIDUALS"]:
             # open up the registered output file, read in xy's
-            pipe = [
-                self.out_name,
-            ]
-            p = pdal.Pipeline(json.dumps(pipe))
+            p = pdal.Reader(self.out_name).pipeline()
             p.execute()
             arrays = p.arrays
             array = arrays[0]

--- a/src/codem/registration/apply.py
+++ b/src/codem/registration/apply.py
@@ -187,6 +187,9 @@ class ApplyRegistration:
             "filename": output_path,
             "metadata": (
                 f"CODEM_VERSION={__version__},"
+                "CODEM_INFO=Data registered and adjusted to "
+                f"{os.path.basename(self.config['FND_FILE'])} by NCALM CODEM. "
+                f"Total registration mean square error {self.registration_rmse:.3f},"
                 "TIFFTAG_IMAGEDESCRIPTION=RegisteredCompliment"
             ),
         }

--- a/src/codem/registration/dsm.py
+++ b/src/codem/registration/dsm.py
@@ -426,7 +426,7 @@ class DsmRegistration:
         self.logger.info(
             f"Saving DSM feature registration parameters to: {output_file}"
         )
-        with open(output_file, "w") as f:
+        with open(output_file, "w", encoding="utf_8") as f:
             f.write("DSM FEATURE REGISTRATION")
             f.write("\n------------------------")
             f.write(f"\nTransformation matrix: \n {X}")
@@ -451,7 +451,7 @@ class DsmRegistration:
                 "\nAssumed global 3D error = +/-3m"
                 f"\n3D_RMSE = +/-{self.rmse_3d:.3f}"
                 "\nTotal Error is computed as √(global_3d_error²+3D_RMSE²)"
-                f"\nTotal Error = +/-{math.hypot(3, self.rmse_3d)}"
+                f"\nTotal Error = +/-{math.hypot(3, self.rmse_3d):.3f}"
             )
             f.write("\n\n")
 

--- a/src/codem/registration/icp.py
+++ b/src/codem/registration/icp.py
@@ -466,7 +466,7 @@ class IcpRegistration:
         output_file = os.path.join(self.config["OUTPUT_DIR"], "registration.txt")
 
         self.logger.info(f"Saving ICP registration parameters to: {output_file}")
-        with open(output_file, "a") as f:
+        with open(output_file, "a", encoding="utf_8") as f:
             f.write("ICP REGISTRATION")
             f.write("\n----------------")
             f.write(f"\nTransformation matrix: \n {X}")

--- a/src/vcd/preprocessing/preprocess.py
+++ b/src/vcd/preprocessing/preprocess.py
@@ -264,7 +264,7 @@ class VCD:
             metadata = (
                 f"TIFFTAG_XRESOLUTION={resolution},"
                 f"TIFFTAG_YRESOLUTION={resolution},"
-                f"TIFFTAG_IMAGEDESCRIPTION={product.description}"
+                f"TIFFTAG_IMAGEDESCRIPTION={product.description},"
                 f"CODEM_VERSION={__version__}"
             )
             gdalopts = (

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -5,7 +5,9 @@ import os
 import pathlib
 
 import codem
+import numpy as np
 import pytest
+from osgeo import gdal
 from point_cloud import manipulate_pc
 from point_cloud import pc_aoi
 from point_cloud import Rotation
@@ -64,7 +66,7 @@ dem_aoi_alterations = [pytest.param(raster_aoi_file, id="DEM AOI Original")]
     "foundation",
     [
         pytest.param(pc_foundation, id="PC Foundation"),
-        pytest.param(dem_foundation, id="DEM Foudnation"),
+        pytest.param(dem_foundation, id="DEM Foundation"),
     ],
 )
 def test_registration(foundation: str, aoi: str, tmp_path: pathlib.Path) -> None:
@@ -106,3 +108,172 @@ def test_registration(foundation: str, aoi: str, tmp_path: pathlib.Path) -> None
     reg_file = codem.apply_registration(fnd_obj, aoi_obj, icp_reg, config)
 
     assert os.path.exists(reg_file)
+
+
+@pytest.mark.parametrize("foundation,compliment", [(dem_foundation, raster_aoi_file)])
+def test_area_or_point(
+    foundation: str, compliment: str, tmp_path: pathlib.Path
+) -> None:
+    """Rasters can have their elevation data represented as the position in the
+    top-left corner (RasterPixelIsArea) or in the middle of the pixel
+    (RasterPixelIsPoint)
+
+
+    Pixel is Area:
+
+       (0)    (1)
+    (0)_|_______|
+        |       |
+        |       |
+    (1)_|_______|
+
+    Pixel is Point:
+
+           (0)     (1)
+         ___|___ ___|___
+        |   |   |   |   |
+    (0)-|---|---|---|---|
+        |___|___|___|___|
+            |       |
+
+    Through the CODEM registration pipeline, data is shifted such that pixel is
+    point is the default representation.
+
+
+    # to change a raster:
+    $ gdal_translate
+    -mo AREA_OR_POINT=POINT
+    --config GTIFF_POINT_GEO_IGNORE True
+    input_pixel_is_area.tif output_pixel_is_point.tif
+    """
+
+    # compliment by default has AREA_OR_PIXEL=AREA
+    compliment_base, extension = os.path.splitext(compliment)
+    alternate = f"{compliment_base}_pixel_is_point{extension}"
+
+    compliment_info = gdal.Info(compliment, format="json")
+    compliment_pixel = compliment_info["metadata"][""]["AREA_OR_POINT"]
+    # create the alternative compliment with the different setup
+    alternate_pixel = "Point" if compliment_pixel.lower() == "area" else "Area"
+
+    # need to set the config option accordingly
+    gdal.SetConfigOption("GTIFF_POINT_GEO_IGNORE", "YES")
+    gdal.Translate(
+        alternate, compliment, options=f"-mo AREA_OR_POINT={alternate_pixel.upper()}"
+    )
+    gdal.SetConfigOption("GTIFF_POINT_GEO_IGNORE", "NO")
+
+    alternate_info = gdal.Info(alternate, format="json")
+    alternate_pixel = alternate_info["metadata"][""]["AREA_OR_POINT"]
+
+    # make sure metadata actually is different
+    assert compliment_pixel.lower() != alternate_pixel.lower()
+
+    # compare bounds with gdal looking at corners
+    assert compliment_info["cornerCoordinates"] != alternate_info["cornerCoordinates"]
+
+    # now we run two registration processes alongside checking if both AOIs are equivalent...
+    output_directory = tmp_path.resolve().as_posix()
+    compliment_config = dataclasses.asdict(
+        codem.CodemRunConfig(foundation, compliment, OUTPUT_DIR=output_directory)
+    )
+    alternate_config = dataclasses.asdict(
+        codem.CodemRunConfig(foundation, alternate, OUTPUT_DIR=output_directory)
+    )
+
+    foundation_comp, compliment_obj = codem.preprocess(compliment_config)
+    foundation_alt, alternate_obj = codem.preprocess(alternate_config)
+
+    # resolutions should be the same
+    assert math.isclose(compliment_obj.resolution, alternate_obj.resolution)
+
+    # transforms should have different offsets
+    assert compliment_obj.transform.xoff != alternate_obj.transform.xoff  # type: ignore
+    assert compliment_obj.transform.yoff != alternate_obj.transform.yoff  # type: ignore
+
+    # let's prep
+    foundation_comp.prep()
+    foundation_alt.prep()
+    compliment_obj.prep()
+    alternate_obj.prep()
+
+    # make sure we actually have the correct attribute set
+    assert compliment_obj.area_or_point.lower() != alternate_obj.area_or_point.lower()
+
+    # GeoData.point_cloud compensates for this offset...
+    assert np.allclose(compliment_obj.point_cloud, alternate_obj.point_cloud)
+
+    dsm_reg_compliment = codem.coarse_registration(
+        foundation_comp, compliment_obj, compliment_config
+    )
+
+    dsm_reg_alternate = codem.coarse_registration(
+        foundation_alt, alternate_obj, alternate_config
+    )
+
+    # we should have the same number of putative matches
+    assert len(dsm_reg_compliment.putative_matches) == len(
+        dsm_reg_alternate.putative_matches
+    )
+
+    # ensure that coarse transformations are different by resolution
+    if compliment_obj.area_or_point.lower() == "area":
+        transform_to_offset = dsm_reg_compliment.transformation
+        transform_to_fix = dsm_reg_alternate.transformation
+    else:
+        transform_to_offset = dsm_reg_alternate.transformation
+        transform_to_fix = dsm_reg_compliment.transformation
+
+    # resolution should be the same
+    pos_offset = transform_to_offset[0:2, -1] + np.array(
+        [compliment_obj.resolution, -compliment_obj.resolution]
+    )
+    assert np.allclose(pos_offset, transform_to_fix[0:2, -1])
+
+    # perform fine registration
+    icp_reg_compliment = codem.fine_registration(
+        foundation_comp, compliment_obj, dsm_reg_compliment, compliment_config
+    )
+    icp_reg_alternate = codem.fine_registration(
+        foundation_alt, alternate_obj, dsm_reg_alternate, alternate_config
+    )
+
+    # ensure that coarse transformations are different by resolution
+    if compliment_obj.area_or_point.lower() == "area":
+        transform_to_offset = icp_reg_compliment.transformation
+        transform_to_fix = icp_reg_alternate.transformation
+    else:
+        transform_to_offset = icp_reg_alternate.transformation
+        transform_to_fix = icp_reg_compliment.transformation
+
+    pos_offset = transform_to_offset[0:2, -1] + np.array(
+        [compliment_obj.resolution, -compliment_obj.resolution]
+    )
+    assert np.allclose(pos_offset, transform_to_fix[0:2, -1])
+
+    # do the registration
+    registered_compliment = codem.apply_registration(
+        foundation_comp, compliment_obj, icp_reg_compliment, compliment_config
+    )
+    registered_alternate = codem.apply_registration(
+        foundation_alt, alternate_obj, icp_reg_alternate, alternate_config
+    )
+
+    registered_compliment_info = gdal.Info(registered_compliment, format="json")
+    registered_alternate_info = gdal.Info(registered_alternate, format="json")
+
+    # bounds between the two datasets should be different
+    assert (
+        registered_compliment_info["cornerCoordinates"]
+        != registered_alternate_info["cornerCoordinates"]
+    )
+
+    # metadata should be preserved between input and registered output
+    assert (
+        registered_compliment_info["metadata"][""]["AREA_OR_POINT"]
+        == compliment_info["metadata"][""]["AREA_OR_POINT"]
+    )
+    assert (
+        registered_alternate_info["metadata"][""]["AREA_OR_POINT"]
+        == alternate_info["metadata"][""]["AREA_OR_POINT"]
+    )


### PR DESCRIPTION
Fixes #64 
Fixes #68

This PR attempts to compensate for raster datasets having mismatches in PixelIsPoint and PixelIsArea between foundation and complement datasets.  

As a side effect, I took the opportunity  to move away from the pdal pipeline construction using json, and instead using the python API with the `|=` operator.
