### PR TITLE
unindent WebSocketHandler definition

### DIFF
--- a/src/codem/lib/log.py
+++ b/src/codem/lib/log.py
@@ -21,7 +21,6 @@ try:
 except ImportError:
     pass
 else:
-
     class CustomJsonFormatter(jsonlogger.JsonFormatter):
         def add_fields(
             self,
@@ -39,20 +38,21 @@ else:
                 log_record["type"] = "log_message"
             return None
 
-    class WebSocketHandler(logging.Handler):
-        def __init__(self, level: str, websocket: "websocket.WebSocket") -> None:
-            super().__init__(level)
-            self.ws = websocket
-            # TODO: check if websocket is already connected?
 
-        def emit(self, record: logging.LogRecord) -> None:
-            msg = self.format(record)
-            _ = self.ws.send(msg)
-            return None
+class WebSocketHandler(logging.Handler):
+    def __init__(self, level: str, websocket: "websocket.WebSocket") -> None:
+        super().__init__(level)
+        self.ws = websocket
+        # TODO: check if websocket is already connected?
 
-        def close(self) -> None:
-            self.ws.close()
-            return super().close()
+    def emit(self, record: logging.LogRecord) -> None:
+        msg = self.format(record)
+        _ = self.ws.send(msg)
+        return None
+
+    def close(self) -> None:
+        self.ws.close()
+        return super().close()
 
 
 class Log:


### PR DESCRIPTION
This addresses the issue where there is an isinstance check in __del__ for the log handler that checks if the log handler is of type WebSocketHandler, and the WebSocketHandler is defined inside the else block that follows the attempt to import websocket and pythonjsonlogger. Since the WebSocketHandler class definition does not use anything from the websocket-client library directly, we can move the definition of it to be on the top level indent.