### PR TITLE
Address numpy 2.0+ issues and bump version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,7 +6,7 @@ on:
       - "dependabot/**"
   pull_request:
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
@@ -32,11 +32,10 @@ jobs:
             libegl1-mesa \
             libopengl0 \
             libgl1 \
-            libgl1-mesa-glx 
+            libgl1-mesa-glx
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          miniforge-variant: Mambaforge
           environment-file: environment.yml
           auto-update-conda: false
           python-version: "3.9"
@@ -44,7 +43,7 @@ jobs:
         run: pip install pytest
       - name: "Install Codem"
         run: pip install .
-      - name: 'Debug Info'
+      - name: "Debug Info"
         run: |
           echo python location: `which python`
           echo python version: `python --version`
@@ -58,65 +57,64 @@ jobs:
     name: lint-check
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        # Semantic version range syntax or exact version of a Python version
-        python-version: '3.12'
-    - name: Install Linting Tools
-      run : |
-        python -m pip install mypy numpy types-PyYAML typing-extensions
-    - name: Run mypy
-      run : mypy src
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 2
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          # Semantic version range syntax or exact version of a Python version
+          python-version: "3.12"
+      - name: Install Linting Tools
+        run: |
+          python -m pip install mypy numpy types-PyYAML typing-extensions
+      - name: Run mypy
+        run: mypy src
   analyze:
     name: analyze
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-    - uses: conda-incubator/setup-miniconda@v3
-      with:
-        miniforge-version: latest
-        miniforge-variant: Mambaforge
-        environment-file: environment.yml
-        auto-update-conda: false
-        python-version: "3.12"
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: 'python'
-        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        queries: +security-and-quality
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 2
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          environment-file: environment.yml
+          auto-update-conda: false
+          python-version: "3.12"
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: "python"
+          # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          queries: +security-and-quality
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ exclude = '''
 
 [tool.mypy]
 plugins = 'numpy.typing.mypy_plugin'
-python_version = 3.9
+python_version = '3.9'
 warn_return_any = true
 disallow_untyped_defs = true
 disallow_untyped_calls = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,24 +5,20 @@ description = "A package for co-registering geospatial data"
 readme = "readme.md"
 license = { text = "Apache-2.0" }
 authors = [
-  { name = "Preston Hartzell", email = "pjhartzell@uh.edu"},
+  { name = "Preston Hartzell", email = "pjhartzell@uh.edu" },
   { name = "Jesse Shanahan" },
-  { name = "Bahirah Adewunmi" }
+  { name = "Bahirah Adewunmi" },
 ]
-maintainers = [
-    { name = "Ognyan Moore", email = "ogi@hobu.co" }
-]
+maintainers = [{ name = "Ognyan Moore", email = "ogi@hobu.co" }]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Information Technology",
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: Apache Software License",
   "Topic :: Scientific/Engineering :: GIS",
-  "Topic :: Scientific/Engineering :: Image Processing"
+  "Topic :: Scientific/Engineering :: Image Processing",
 ]
-dependencies = [
-  "typing-extensions"
-]
+dependencies = ["typing-extensions"]
 dynamic = ["version"]
 
 [project.urls]
@@ -30,7 +26,7 @@ homepage = "https://github.com/NCALM-UH/CODEM"
 repository = "https://github.com/NCALM-UH/CODEM"
 
 [tool.setuptools]
-package-dir = {"" =  "src"}
+package-dir = { "" = "src" }
 zip-safe = false
 
 [tool.setuptools.dynamic]
@@ -66,6 +62,7 @@ exclude = '''
 '''
 
 [tool.mypy]
+plugins = 'numpy.typing.mypy_plugin'
 python_version = 3.9
 warn_return_any = true
 disallow_untyped_defs = true
@@ -108,6 +105,6 @@ module = [
   "skimage",
   "skimage.measure",
   "trimesh",
-  "websocket"
+  "websocket",
 ]
 ignore_missing_imports = true

--- a/src/codem/__init__.py
+++ b/src/codem/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.25.5"
+__version__ = "0.25.6"
 
 import codem.lib.log as log
 import codem.lib.resources as resources

--- a/src/codem/preprocessing/preprocess.py
+++ b/src/codem/preprocessing/preprocess.py
@@ -227,8 +227,8 @@ class GeoData:
             mask = dsm != self.nodata
         else:
             mask = ~nan_mask
-
-        return mask.astype(np.uint8)
+        mask = mask.astype(np.uint8)
+        return mask
 
     def _infill(self) -> None:
         """

--- a/src/codem/preprocessing/preprocess.py
+++ b/src/codem/preprocessing/preprocess.py
@@ -553,13 +553,6 @@ class DSM(GeoData):
                 )
                 self.native_resolution = abs(T.a)
                 self.units = "m"
-            elif not data.crs.is_valid:
-                self.logger.warning(
-                    f"CRS {data.crs.to_wkt()} is not valid, assuming linear units "
-                    "are meters."
-                )
-                self.native_resolution = abs(T.a)
-                self.units = "m"
             elif not data.crs.is_projected:
                 self.logger.info("CRS is not projected, converting to meters")
 

--- a/src/codem/preprocessing/preprocess.py
+++ b/src/codem/preprocessing/preprocess.py
@@ -480,7 +480,7 @@ class DSM(GeoData):
 
             # Scale the elevation values into meters
             mask = (self._get_nodata_mask(self.dsm)).astype(bool)
-            if np.can_cast(self.units_factor, self.dsm.dtype, casting="same_kind"):
+            if np.can_cast(np.array([self.units_factor]), self.dsm.dtype, casting="same_kind"):
                 self.dsm[mask] *= self.units_factor
             elif isinstance(self.units_factor, float):
                 if self.units_factor.is_integer():

--- a/src/codem/registration/dsm.py
+++ b/src/codem/registration/dsm.py
@@ -377,8 +377,8 @@ class DsmRegistration:
             temp = transform * (cr)
             xy.append([temp[0], temp[1]])
 
-        z_ = np.asarray(z)
-        xy_ = np.asarray(xy)
+        z_ = np.asarray(z, dtype=np.float64)
+        xy_ = np.asarray(xy, dtype=np.float64)
         return np.vstack((xy_.T, z_)).T
 
     def _get_rmse(self) -> None:

--- a/src/codem/registration/dsm.py
+++ b/src/codem/registration/dsm.py
@@ -379,7 +379,8 @@ class DsmRegistration:
 
         z_ = np.asarray(z, dtype=np.float64)
         xy_ = np.asarray(xy, dtype=np.float64)
-        return np.vstack((xy_.T, z_)).T
+        result: np.ndarray = np.vstack((xy_.T, z_)).T
+        return result
 
     def _get_rmse(self) -> None:
         """
@@ -571,7 +572,8 @@ class Scaled3dSimilarityTransform:
         # Eq. (40) and (43).
         rank = np.linalg.matrix_rank(A)
         if rank == 0:
-            return np.full_like(T, np.nan)
+            result: np.ndarray = np.full_like(T, np.nan)
+            return result
         elif rank == dim - 1:
             if np.linalg.det(U) * np.linalg.det(V) > 0:
                 T[:dim, :dim] = U @ V
@@ -696,7 +698,8 @@ class Unscaled3dSimilarityTransform:
         # Eq. (40) and (43).
         rank = np.linalg.matrix_rank(A)
         if rank == 0:
-            return np.full_like(T, np.nan)
+            result: np.ndarray = np.full_like(T, np.nan)
+            return result
         elif rank == dim - 1:
             if np.linalg.det(U) * np.linalg.det(V) > 0:
                 T[:dim, :dim] = U @ V


### PR DESCRIPTION
This PR addresses handles a handful of changes

- Addresses a handful of changes that came with numpy 2.0+
- Fix some type annotations
- Remove soon to be deprecated use of `rasterio.crs.is_valid`
- Remove deprecated reference of `Mambaforge` for miniforge variant
- Bump version