### PR TITLE
Implement reading point cloud data from generic PDAL pipelines

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,7 +32,7 @@ jobs:
             libegl1-mesa \
             libopengl0 \
             libgl1 \
-            libgl1-mesa-glx
+            libglx-mesa0
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,7 +29,6 @@ jobs:
         run: |
           sudo apt-get update -y --allow-releaseinfo-change
           sudo apt-get install --no-install-recommends -y \
-            libegl1-mesa \
             libopengl0 \
             libgl1 \
             libglx-mesa0

--- a/src/codem/__init__.py
+++ b/src/codem/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.25.6"
+__version__ = "0.26.0"
 
 import codem.lib.log as log
 import codem.lib.resources as resources

--- a/src/codem/registration/apply.py
+++ b/src/codem/registration/apply.py
@@ -19,6 +19,7 @@ from typing import Union
 
 import codem.lib.resources as r
 import numpy as np
+import numpy.typing as npt
 import pdal
 import rasterio
 import trimesh
@@ -67,8 +68,8 @@ class ApplyRegistration:
         fnd_obj: GeoData,
         aoi_obj: GeoData,
         registration_parameters: RegistrationParameters,
-        residual_vectors: np.ndarray,
-        residual_origins: np.ndarray,
+        residual_vectors: npt.NDArray,
+        residual_origins: npt.NDArray,
         config: CodemParameters,
         output_format: Optional[str],
     ) -> None:
@@ -117,7 +118,7 @@ class ApplyRegistration:
         meters_to_fnd = np.eye(4) * (1 / self.fnd_units_factor)
         meters_to_fnd[3, 3] = 1
 
-        aoi_to_fnd_array: np.ndarray = (
+        aoi_to_fnd_array: npt.NDArray = (
             meters_to_fnd @ self.registration_transform @ aoi_to_meters
         )
 
@@ -223,8 +224,8 @@ class ApplyRegistration:
             rows = np.arange(dsm.shape[0], dtype=np.float64)
             cols = np.arange(dsm.shape[1], dtype=np.float64)
             uu, vv = np.meshgrid(cols, rows)
-            u = np.reshape(uu, -1)
-            v = np.reshape(vv, -1)
+            u: npt.NDArray = np.reshape(uu, -1)
+            v: npt.NDArray = np.reshape(vv, -1)
             if area_or_point == "Area":
                 u += 0.5
                 v += 0.5
@@ -412,8 +413,8 @@ class ApplyRegistration:
             )
 
     def _interpolate_residuals(
-        self, x: np.ndarray, y: np.ndarray
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        self, x: npt.NDArray, y: npt.NDArray
+    ) -> Tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
         """
         Interpolate ICP residuals at registered AOI x,y locations. The
         registration is solved using a gridded set of points, while the AOI

--- a/src/codem/registration/dsm.py
+++ b/src/codem/registration/dsm.py
@@ -24,6 +24,7 @@ from typing import Tuple
 
 import cv2
 import numpy as np
+import numpy.typing as npt
 from codem.preprocessing.preprocess import CodemParameters
 from codem.preprocessing.preprocess import GeoData
 from codem.preprocessing.preprocess import RegistrationParameters
@@ -298,7 +299,7 @@ class DsmRegistration:
         fnd_xyz = (self.transformation @ aoi_xyz.T).T
         fnd_xy = np.vstack((fnd_xyz[:, 0:2].T, np.ones((1, 4)))).T
 
-        F_inverse = np.reshape(np.asarray(~self.fnd_obj.transform), (3, 3))
+        F_inverse: npt.NDArray[np.float64] = np.reshape(np.asarray(~self.fnd_obj.transform), (3, 3))
         fnd_uv = (F_inverse @ fnd_xy.T).T
         fnd_uv = fnd_uv[:, 0:2]
 
@@ -404,7 +405,7 @@ class DsmRegistration:
         """
         Stores registration results in a dictionary and writes them to a file
         """
-        X = self.transformation
+        X: npt.NDArray[np.float64] = self.transformation
         R = X[0:3, 0:3]
         c = np.sqrt(R[0, 0] ** 2 + R[1, 0] ** 2 + R[2, 0] ** 2)
         omega = np.rad2deg(np.arctan2(R[2, 1] / c, R[2, 2] / c))

--- a/tests/data/pipeline.json
+++ b/tests/data/pipeline.json
@@ -1,0 +1,20 @@
+{
+  "pipeline":
+  [
+    {
+      "filename": "./tests/data/pc.laz",
+      "type": "readers.las"
+    },
+    {
+      "type": "filters.expression",
+      "expression": "Intensity < 250"
+    },
+    {
+      "type": "writers.gdal",
+      "resolution": 1,
+      "filename":"output.tif"
+    }
+
+  ]
+}
+

--- a/tests/point_cloud.py
+++ b/tests/point_cloud.py
@@ -81,18 +81,24 @@ def manipulate_pc(
     return output_file
 
 
-def pc_aoi(tmp_location: str, pc_foundation: str, aoi_shapefile: str) -> str:
+
+def pc_pipeline(tmp_location: str, pc_foundation: str, aoi_shapefile: str) -> str:
     os.makedirs(tmp_location, exist_ok=True)
     output_file = tempfile.NamedTemporaryFile(
         dir=tmp_location, suffix=".laz", delete=False
     ).name
-    pipeline = pdal.Reader(pc_foundation)
+    from codem.preprocessing.preprocess import PipelineReader
+
+    pipeline = PipelineReader(pc_foundation).get()
+
     pipeline |= pdal.Filter.ferry(dimensions="=>AOIDimension")
     pipeline |= pdal.Filter.assign(assignment="AOIDimension[:]=1")
     pipeline |= pdal.Filter.overlay(
         dimension="AOIDimension", datasource=aoi_shapefile, where="AOIDimension == 1"
     )
     pipeline |= pdal.Filter.range(limits="AOIDimension[0:0]")
+
     pipeline |= pdal.Writer.las(filename=output_file, minor_version=4, forward="all")
     pipeline.execute()
     return output_file
+

--- a/tests/point_cloud.py
+++ b/tests/point_cloud.py
@@ -73,9 +73,9 @@ def manipulate_pc(
 
     temp_location = os.path.dirname(pc_aoi)
     output_file = tempfile.NamedTemporaryFile(
-        dir=temp_location, suffix=".laz", delete=False
+        dir=temp_location, suffix=".copc.laz", delete=False
     ).name
-    pipeline.append({"type": "writers.las", "filename": output_file, "forward": "all"})
+    pipeline.append({"type": "writers.copc", "filename": output_file, "forward": "all"})
     p = pdal.Pipeline(json.dumps(pipeline))
     p.execute()
     return output_file
@@ -85,7 +85,7 @@ def manipulate_pc(
 def pc_pipeline(tmp_location: str, pc_foundation: str, aoi_shapefile: str) -> str:
     os.makedirs(tmp_location, exist_ok=True)
     output_file = tempfile.NamedTemporaryFile(
-        dir=tmp_location, suffix=".laz", delete=False
+        dir=tmp_location, suffix=".copc.laz", delete=False
     ).name
     from codem.preprocessing.preprocess import PipelineReader
 
@@ -98,7 +98,7 @@ def pc_pipeline(tmp_location: str, pc_foundation: str, aoi_shapefile: str) -> st
     )
     pipeline |= pdal.Filter.range(limits="AOIDimension[0:0]")
 
-    pipeline |= pdal.Writer.las(filename=output_file, minor_version=4, forward="all")
+    pipeline |= pdal.Writer.copc(filename=output_file, forward="all")
     pipeline.execute()
     return output_file
 

--- a/tests/raster.py
+++ b/tests/raster.py
@@ -5,6 +5,7 @@ from typing import NamedTuple
 from typing import Optional
 
 from osgeo import gdal
+gdal.UseExceptions()
 
 
 class Translation(NamedTuple):

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -8,6 +8,7 @@ import codem
 import numpy as np
 import pytest
 from osgeo import gdal
+gdal.UseExceptions()
 from point_cloud import manipulate_pc
 from point_cloud import pc_aoi
 from point_cloud import Rotation

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -10,7 +10,7 @@ import pytest
 from osgeo import gdal
 gdal.UseExceptions()
 from point_cloud import manipulate_pc
-from point_cloud import pc_aoi
+from point_cloud import pc_pipeline
 from point_cloud import Rotation
 from point_cloud import Translation
 from raster import dem_aoi
@@ -19,19 +19,22 @@ from raster import dem_aoi
 aoi_shapefile = os.path.abspath("tests/data/aoi_shapefile/aoi.shp")
 dem_foundation = os.path.abspath("tests/data/dem.tif")
 pc_foundation = os.path.abspath("tests/data/pc.laz")
+pipeline_foundation = os.path.abspath("tests/data/pipeline.json")
 temporary_directory = os.path.abspath("tests/data/temporary")
 
 
-def make_pc_aoi(aoi_temp_directory: str = temporary_directory) -> str:
-    return pc_aoi(aoi_temp_directory, pc_foundation, aoi_shapefile)
-
+def make_pc_file(aoi_temp_directory: str = temporary_directory) -> str:
+    return pc_pipeline(aoi_temp_directory, pc_foundation, aoi_shapefile)
 
 def make_raster_aoi(aoi_temp_directory: str = temporary_directory) -> str:
     return dem_aoi(aoi_temp_directory, dem_foundation, aoi_shapefile)
 
+def make_pc_pipeline(aoi_temp_directory: str = temporary_directory) -> str:
+    return pc_pipeline(aoi_temp_directory, pipeline_foundation, aoi_shapefile)
 
-pc_aoi_file = make_pc_aoi()
+pc_aoi_file = make_pc_file()
 raster_aoi_file = make_raster_aoi()
+pipeline_file = make_pc_pipeline()
 
 pc_aoi_alterations = [
     pytest.param(pc_aoi_file, id="PC AOI Original"),
@@ -68,6 +71,7 @@ dem_aoi_alterations = [pytest.param(raster_aoi_file, id="DEM AOI Original")]
     [
         pytest.param(pc_foundation, id="PC Foundation"),
         pytest.param(dem_foundation, id="DEM Foundation"),
+        pytest.param(pipeline_foundation, id="Pipeline Foundation"),
     ],
 )
 def test_registration(foundation: str, aoi: str, tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
It is now possible to provide a generic JSON pdal pipeline, and it will strip the writer off of it and use it. This should complete the desired capability in #93 