### PR TITLE
Handle the case with merged PC files

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,26 +18,21 @@ concurrency:
 jobs:
   test:
     name: test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -el {0}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install apt dependencies
-        run: |
-          sudo apt-get update -y --allow-releaseinfo-change
-          sudo apt-get install --no-install-recommends -y \
-            libopengl0 \
-            libgl1 \
-            libglx-mesa0
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
           environment-file: environment.yml
           auto-update-conda: false
-          python-version: "3.9"
+          python-version: "3.12"
+          conda-remove-defaults: true
+          channels: conda-forge
       - name: "Install Test Framework"
         run: pip install pytest
       - name: "Install Codem"
@@ -88,6 +83,8 @@ jobs:
           environment-file: environment.yml
           auto-update-conda: false
           python-version: "3.12"
+          conda-remove-defaults: true
+          channels: conda-forge
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/src/codem/__init__.py
+++ b/src/codem/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.26.0"
+__version__ = "0.26.1"
 
 import codem.lib.log as log
 import codem.lib.resources as resources

--- a/src/codem/preprocessing/preprocess.py
+++ b/src/codem/preprocessing/preprocess.py
@@ -689,7 +689,13 @@ class PointCloud(GeoData):
         pipeline.execute()
 
         metadata = pipeline.metadata["metadata"]
-        reader_metadata = [val for key, val in metadata.items() if "readers" in key]
+        reader_metadata = []
+        for key, val in metadata.items():
+            if key.startswith("readers"):
+                if isinstance(val, list):
+                    reader_metadata.extend(val)
+                else:
+                    reader_metadata.append(val)
         try:
             crs = CRS.from_string(reader_metadata[0]["srs"]["horizontal"])
         except (CRSError, IndexError, KeyError):

--- a/src/codem/registration/dsm.py
+++ b/src/codem/registration/dsm.py
@@ -261,7 +261,7 @@ class DsmRegistration:
         if c < 0.67 or c > 1.5:
             warnings.warn(
                 (
-                    "Coarse regsistration solved scale between datasets exceeds 50%. "
+                    "Coarse registration solved scale between datasets exceeds 50%. "
                     "Registration is likely to fail"
                 ),
                 category=RuntimeWarning,

--- a/src/codem/registration/icp.py
+++ b/src/codem/registration/icp.py
@@ -118,7 +118,7 @@ class IcpRegistration:
         fixed = self.fixed - fixed_mean
         moving = moving - fixed_mean
 
-        fixed_tree = spatial.cKDTree(fixed)
+        fixed_tree = spatial.KDTree(fixed)
 
         cumulative_transform = np.eye(4)
         moving_transformed = moving
@@ -133,7 +133,6 @@ class IcpRegistration:
             _, idx = fixed_tree.query(
                 moving_transformed, k=1, distance_upper_bound=self.outlier_thresh
             )
-
             include_fixed = idx[idx < fixed.shape[0]]
             include_moving = idx < fixed.shape[0]
             temp_fixed = fixed[include_fixed]
@@ -142,7 +141,8 @@ class IcpRegistration:
 
             if temp_fixed.shape[0] < 7:
                 raise RuntimeError(
-                    "At least 7 points within the ICP outlier threshold are required."
+                    "At least 7 points within the ICP outlier threshold are required ("
+                    f"{temp_fixed.shape[0]} detected)."
                 )
 
             weights = self._get_weights(


### PR DESCRIPTION
When using a PDAL pipeline as one of the arguments for codem with filters.merge, the list comprehension to construct the reader metadata is in the form of a list, and not a dictionary.  This commit replaces the list comprehension with a generic for loop over the metadata, and if the reader metadata value is in the form of a list, the metadata list is extended to (instead of appended).

Supersedes  #97 